### PR TITLE
Dependency update

### DIFF
--- a/packages/automerge-client/main.js
+++ b/packages/automerge-client/main.js
@@ -131,4 +131,19 @@ export default class AutomergeClient {
       )
     }
   }
+
+  unsubscribe(ids) {
+    if (ids.length <= 0) return
+    
+    this.subscribeList = this.subscribeList.filter((value,index) => {
+      return ids.indexOf(value) == -1
+    })
+    
+    if (this.socket.readyState === 1) {
+      // OPEN
+      this.socket.send(
+        JSON.stringify({ action: 'unsubscribe', ids: ids.filter(unique) }),
+      )
+    }
+  }
 }

--- a/packages/automerge-server-test/package.json
+++ b/packages/automerge-server-test/package.json
@@ -23,6 +23,6 @@
     "ws": "^6.0.0"
   },
   "devDependencies": {
-    "nodemon": "^1.18.4"
+    "nodemon": "^2.0.2"
   }
 }


### PR DESCRIPTION
When running 'npm install', nodemon will fail to install due to a dependency error caused by flatmap-stream. Updating to the latest version of nodemon solves this issue.