### PR TITLE
Added unsubscribe function on client library

### DIFF
--- a/packages/automerge-client/main.js
+++ b/packages/automerge-client/main.js
@@ -131,4 +131,19 @@ export default class AutomergeClient {
       )
     }
   }
+
+  unsubscribe(ids) {
+    if (ids.length <= 0) return
+    
+    this.subscribeList = this.subscribeList.filter((value,index) => {
+      return ids.indexOf(value) == -1
+    })
+    
+    if (this.socket.readyState === 1) {
+      // OPEN
+      this.socket.send(
+        JSON.stringify({ action: 'unsubscribe', ids: ids.filter(unique) }),
+      )
+    }
+  }
 }


### PR DESCRIPTION
While the unsubscribe functionality is defined and implemented in 'automerge-server' this function is missing from the client library. 

The code removes the ids from the client 'subscribeList' and sends the appropriate request to the server. 

