### PR TITLE
Client pause-resume documents functionality

### DIFF
--- a/packages/automerge-client/main.js
+++ b/packages/automerge-client/main.js
@@ -131,4 +131,19 @@ export default class AutomergeClient {
       )
     }
   }
+
+  unsubscribe(ids) {
+    if (ids.length <= 0) return
+    
+    this.subscribeList = this.subscribeList.filter((value,index) => {
+      return ids.indexOf(value) == -1
+    })
+    
+    if (this.socket.readyState === 1) {
+      // OPEN
+      this.socket.send(
+        JSON.stringify({ action: 'unsubscribe', ids: ids.filter(unique) }),
+      )
+    }
+  }
 }

--- a/packages/automerge-server-test/package.json
+++ b/packages/automerge-server-test/package.json
@@ -23,6 +23,6 @@
     "ws": "^6.0.0"
   },
   "devDependencies": {
-    "nodemon": "^1.18.4"
+    "nodemon": "^2.0.2"
   }
 }


### PR DESCRIPTION
Hi, 

For a project I'm working on, it is desirable to not update the document (hence the UI) when a user is editing an input field. This would cause confusion

To remedy this, it is proposed to create two functions 'pause' and 'resume' that take an array of document ids. Once a document is paused, the onChange function will not add this document to the docSet (thus propagating changes to the server). 

This suggestion actually comes from one of the main library contributors and creator: 

![image](https://user-images.githubusercontent.com/8573439/73190511-65c20c00-4126-11ea-896f-fa17186ed7a2.png)

Please take a look at the code and let me know if this looks good to you or anything should be changed to accommodate this kind of functionality 

Thanks again for the library you created